### PR TITLE
fix Don't Call PropTypes Warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import hoistStatics from 'hoist-non-react-statics'
 import isEmpty from 'lodash.isempty'


### PR DESCRIPTION
React.PropTypes is deprecated as of React v15.5. Use the prop-types library instead.